### PR TITLE
Event simplification and fix-up for Mac

### DIFF
--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -630,10 +630,13 @@ void SafeCombinationEntryDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
     bool oldYubiChallenge = ::wxGetKeyState(WXK_SHIFT); // for pre-0.94 databases
     if (PerformChallengeResponse(this, m_password, response, oldYubiChallenge)) {
       m_password = response;
-      ProcessPhrase();
-      UpdateStatus();
+      if (ProcessPhrase()) {
+        EndModal(wxID_OK);
+      }
     }
   }
+  EllipsizeFilePathname();
+  UpdateStatus();
 }
 
 void SafeCombinationEntryDlg::OnPollingTimer(wxTimerEvent &evt)
@@ -653,7 +656,7 @@ void SafeCombinationEntryDlg::OnDBSelectionChange(wxCommandEvent& WXUNUSED(event
 
 void SafeCombinationEntryDlg::UpdateReadOnlyCheckbox()
 {
-  wxFileName fn(m_filenameCB->GetValue());
+  wxFileName fn(m_filename);
 
   // Do nothing if the file doesn't exist
   if ( fn.FileExists() ) {

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -289,8 +289,8 @@ void SafeCombinationEntryDlg::CreateControls()
   m_filenameCB->Append(recentFiles);
   // The underlying native combobox widget might not yet be ready
   //  to hand back the string we just added
-  wxCommandEvent cmdEvent(wxEVT_COMBOBOX, m_filenameCB->GetId());
-  GetEventHandler()->AddPendingEvent(cmdEvent);
+//  wxCommandEvent cmdEvent(wxEVT_COMBOBOX, m_filenameCB->GetId());
+//  GetEventHandler()->AddPendingEvent(cmdEvent);
   SetIcons(wxGetApp().GetAppIcons());
 }
 

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -384,17 +384,14 @@ void SafeCombinationEntryDlg::OnOk( wxCommandEvent& )
       wxMessageDialog err(this, _("File or path not found."),
                           _("Error"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
-      EllipsizeFilePathname();
       m_filenameCB->SetFocus();
       return;
     }
     if (ProcessPhrase()) {
       EndModal(wxID_OK);
     }
-    else {
-      EllipsizeFilePathname();
-    }
-  } // Validate && TransferDataFromWindow
+  } // TransferDataFromWindow
+  EllipsizeFilePathname();
 }
 
 bool SafeCombinationEntryDlg::ProcessPhrase()

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -244,6 +244,7 @@ void SafeCombinationEntryDlg::CreateControls()
   m_filenameCB->Bind(wxEVT_KILL_FOCUS, [&](wxFocusEvent& WXUNUSED(event)) {
     m_filename = m_filenameCB->GetValue(); // The user may have changed the file name or path manually.
     EllipsizeFilePathname();
+    UpdateReadOnlyCheckbox();
   });
 
   // Event handler to update the file path name string if the size of the combobox changed.
@@ -276,6 +277,7 @@ void SafeCombinationEntryDlg::OnActivate( wxActivateEvent& event )
     if (!m_filename.empty()) {
       FindWindow(ID_COMBINATION)->SetFocus();
       EllipsizeFilePathname();
+      UpdateReadOnlyCheckbox();
 #ifdef __WXOSX__
       // On macOS the ellipsized text gets overwritten by the full pathname
       // sometime after OnActivate returns.  I suspect the validator is (re)loading the

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -235,17 +235,18 @@ void SafeCombinationEntryDlg::CreateControls()
 ////@end SafeCombinationEntryDlg content construction
   m_combinationEntry->SetValidatorTarget(& m_password);
 
-  // Event handler to show full path of filename as tooltip.
-  m_filenameCB->Bind(wxEVT_MOTION, [&](wxMouseEvent& WXUNUSED(event)) {
-    m_filenameCB->SetToolTip(m_filename);
-  });
+//  // Event handler to show full path of filename as tooltip.
+//  m_filenameCB->Bind(wxEVT_MOTION, [&](wxMouseEvent& WXUNUSED(event)) {
+//    m_filenameCB->SetToolTip(m_filename);
+//  });
 
   // Event handler to shorten the file path name if it doesn't fit into the combobox.
-  m_filenameCB->Bind(wxEVT_COMBOBOX, [&](wxCommandEvent& WXUNUSED(event)) {
-    m_filename = m_filenameCB->GetValue(); // Update for tooltip which shows the full path
-    EllipsizeFilePathname();
-    // EllipsizeFilePathname is build up in wxEVT_KILL_FOCUS
-  });
+//  m_filenameCB->Bind(wxEVT_COMBOBOX, [&](wxCommandEvent& WXUNUSED(event)) {
+//    m_filename = m_filenameCB->GetValue(); // Update for tooltip which shows the full path
+//    m_filenameCB->SetToolTip(m_filename);
+//    UpdateReadOnlyCheckbox();
+//    //EllipsizeFilePathname();
+//  });
 
   // Event handler to show the full file path name for editing if text entry field of combobox got the focus.
   m_filenameCB->Bind(wxEVT_SET_FOCUS, [&](wxFocusEvent& WXUNUSED(event)) {
@@ -267,11 +268,13 @@ void SafeCombinationEntryDlg::CreateControls()
   });
 
   // Event handler to update the internal member that is used to show the tooltip.
-  m_filenameCB->Bind(wxEVT_TEXT, [&](wxCommandEvent& WXUNUSED(event)) {
-    if (m_filenameCB->HasFocus()) {
-      m_filename = m_filenameCB->GetValue(); // The user may have changed the file name or path manually.
-    }
-  });
+  // 2024-07, v3.2.4: On macOS, ChangeValue() generates this event even though the documenatation
+  // says it does not.  That causes some problems with respect to EllipsizeFilePathname().
+//  m_filenameCB->Bind(wxEVT_TEXT, [&](wxCommandEvent& WXUNUSED(event)) {
+//    if (m_filenameCB->HasFocus()) {
+//      m_filename = m_filenameCB->GetValue(); // The user may have changed the file name or path manually.
+//    }
+//  });
 
 #if (REVISION == 0)
   m_version->SetLabel(wxString::Format(wxT("V%d.%d %ls"),
@@ -646,6 +649,8 @@ void SafeCombinationEntryDlg::OnPollingTimer(wxTimerEvent &evt)
 
 void SafeCombinationEntryDlg::OnDBSelectionChange(wxCommandEvent& WXUNUSED(event))
 {
+  m_filename = m_filenameCB->GetValue(); // Update for tooltip which shows the full path
+  m_filenameCB->SetToolTip(m_filename);
   UpdateReadOnlyCheckbox();
 }
 
@@ -697,4 +702,6 @@ void SafeCombinationEntryDlg::EllipsizeFilePathname()
       (m_filenameCB->GetSize()).GetWidth() - 50
     )
   );
+  // Make sure the tooltip has the current full filename
+  m_filenameCB->SetToolTip(m_filename);
 }

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -276,6 +276,12 @@ void SafeCombinationEntryDlg::OnActivate( wxActivateEvent& event )
     if (!m_filename.empty()) {
       FindWindow(ID_COMBINATION)->SetFocus();
       EllipsizeFilePathname();
+#ifdef __WXOSX__
+      // On macOS the ellipsized text gets overwritten by the full pathname
+      // sometime after OnActivate returns.  I suspect the validator is (re)loading the
+      // control.  This hack forces a correction.
+      m_filenameCB->PostSizeEvent();
+#endif
     }
     m_postInitDone = true;
   }
@@ -626,7 +632,7 @@ void SafeCombinationEntryDlg::OnDBSelectionChange(wxCommandEvent& WXUNUSED(event
   m_filename = m_filenameCB->GetValue(); // Update for tooltip which shows the full path
   m_filenameCB->SetToolTip(m_filename);
   // On Linux, after selecting from the list nothing has focus, so the name should be ellipsized.
-  // On macOS, the combobox keeps focus, so this should be skipped
+  // On macOS, the combobox keeps focus, so this will be skipped
   if (!m_filenameCB->HasFocus()) {
     EllipsizeFilePathname();
   }

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -235,19 +235,6 @@ void SafeCombinationEntryDlg::CreateControls()
 ////@end SafeCombinationEntryDlg content construction
   m_combinationEntry->SetValidatorTarget(& m_password);
 
-//  // Event handler to show full path of filename as tooltip.
-//  m_filenameCB->Bind(wxEVT_MOTION, [&](wxMouseEvent& WXUNUSED(event)) {
-//    m_filenameCB->SetToolTip(m_filename);
-//  });
-
-  // Event handler to shorten the file path name if it doesn't fit into the combobox.
-//  m_filenameCB->Bind(wxEVT_COMBOBOX, [&](wxCommandEvent& WXUNUSED(event)) {
-//    m_filename = m_filenameCB->GetValue(); // Update for tooltip which shows the full path
-//    m_filenameCB->SetToolTip(m_filename);
-//    UpdateReadOnlyCheckbox();
-//    //EllipsizeFilePathname();
-//  });
-
   // Event handler to show the full file path name for editing if text entry field of combobox got the focus.
   m_filenameCB->Bind(wxEVT_SET_FOCUS, [&](wxFocusEvent& WXUNUSED(event)) {
     m_filenameCB->ChangeValue(m_filename);
@@ -267,15 +254,6 @@ void SafeCombinationEntryDlg::CreateControls()
     }
   });
 
-  // Event handler to update the internal member that is used to show the tooltip.
-  // 2024-07, v3.2.4: On macOS, ChangeValue() generates this event even though the documenatation
-  // says it does not.  That causes some problems with respect to EllipsizeFilePathname().
-//  m_filenameCB->Bind(wxEVT_TEXT, [&](wxCommandEvent& WXUNUSED(event)) {
-//    if (m_filenameCB->HasFocus()) {
-//      m_filename = m_filenameCB->GetValue(); // The user may have changed the file name or path manually.
-//    }
-//  });
-
 #if (REVISION == 0)
   m_version->SetLabel(wxString::Format(wxT("V%d.%d %ls"),
                                        MAJORVERSION, MINORVERSION, SPECIALBUILD));
@@ -287,10 +265,6 @@ void SafeCombinationEntryDlg::CreateControls()
   wxArrayString recentFiles;
   wxGetApp().recentDatabases().GetAll(recentFiles);
   m_filenameCB->Append(recentFiles);
-  // The underlying native combobox widget might not yet be ready
-  //  to hand back the string we just added
-//  wxCommandEvent cmdEvent(wxEVT_COMBOBOX, m_filenameCB->GetId());
-//  GetEventHandler()->AddPendingEvent(cmdEvent);
   SetIcons(wxGetApp().GetAppIcons());
 }
 

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -651,6 +651,11 @@ void SafeCombinationEntryDlg::OnDBSelectionChange(wxCommandEvent& WXUNUSED(event
 {
   m_filename = m_filenameCB->GetValue(); // Update for tooltip which shows the full path
   m_filenameCB->SetToolTip(m_filename);
+  // On Linux, after selecting from the list nothing has focus, so the name should be ellipsized.
+  // On macOS, the combobox keeps focus, so this should be skipped
+  if (!m_filenameCB->HasFocus()) {
+    EllipsizeFilePathname();
+  }
   UpdateReadOnlyCheckbox();
 }
 

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.h
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.h
@@ -151,7 +151,6 @@ protected:
 private:
   StringX m_password;
   wxString m_filename;
-  wxString m_ellipsizedFilename = wxEmptyString;
   bool m_readOnly;
   PWScore &m_core;
   bool m_postInitDone = false;

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -258,6 +258,11 @@ void SafeCombinationPromptDlg::OnActivate(wxActivateEvent& WXUNUSED(event))
 {
   if (!m_DialogActivated) {
     EllipsizeFilePathname();
+#ifdef __WXOSX__
+    // On macOS the ellipsized text gets overwritten by the full pathname
+    // sometime after OnActivate returns.  This hack forces a correction.
+    m_textCtrlFilename->PostSizeEvent();
+#endif
     m_DialogActivated = true;
   }
 }

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -320,6 +320,11 @@ void SafeCombinationPromptDlg::OnCancelClick(wxCommandEvent& WXUNUSED(evt))
 void SafeCombinationPromptDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
 {
   m_scctrl->AllowEmptyCombinationOnce();  // Allow blank password when Yubi's used
+
+  // For the validation process, put the full file path name back into the text input field.
+  // Calling 'EllipsizeFilePathname' will undo this.
+  m_textCtrlFilename->ChangeValue(m_filename);
+
   if (Validate() && TransferDataFromWindow()) {
     if (!pws_os::FileExists(tostdstring(m_filename))) {
       wxMessageDialog err(this, _("File or path not found."),
@@ -332,10 +337,13 @@ void SafeCombinationPromptDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
     bool oldYubiChallenge = ::wxGetKeyState(WXK_SHIFT); // for pre-0.94 databases
     if (PerformChallengeResponse(this, m_password, response, oldYubiChallenge)) {
       m_password = response;
-      ProcessPhrase();
-      UpdateStatus();
+      if (ProcessPhrase()) {
+        EndModal(wxID_OK);
+      }
     }
   }
+  EllipsizeFilePathname();
+  UpdateStatus();
 }
 
 void SafeCombinationPromptDlg::OnPollingTimer(wxTimerEvent &evt)

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -251,6 +251,7 @@ void SafeCombinationPromptDlg::EllipsizeFilePathname()
       (m_textCtrlFilename->GetSize()).GetWidth() - 18
     )
   );
+  m_textCtrlFilename->SetToolTip(m_filename);
 }
 
 void SafeCombinationPromptDlg::OnActivate(wxActivateEvent& WXUNUSED(event))


### PR DESCRIPTION
Related to pwsafe/pwsafe#1335

Since this is based on your branch, I thought this would be the easiest way to present it for your consideration. I've tested it, and had consistent behavior, on the following platforms:

macOS M1Max Sonoma 14.5, Xcode 15.4, wx 3.2.4 and 3.2.5
Fedora 40 ARM64 VMware, Xfce/X11, gcc 14.1.1, wx 3.2.4 and 3.0.5, GTK 3.24.42
Fedora 40 ARM64 VMware, KDE/Wayland, gcc 14.1.1, wx 3.2.4 and 3.0.5, GTK 3.24.42
Ubuntu 24.04 ARM64 VMware, Gnome/Wayland, gcc 13.2.0, wx 3.2.4, GTK 3.24.41
I'll try a Flatpak build sometime soon.
